### PR TITLE
Add support for MSO1074/1104

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pyvisa-py = ">0.7.2"
+pyvisa-py = ">=0.7.2"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pyvisa-py = "*"
+pyvisa-py = ">0.7.2"
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ under Windows, Linux and macOS.
 
 ![example screen grab](./assets/example-grab.png)
 
-_Note: At present, `grab-o-scope` supports the Rigol DHO924 and DS1054Z oscilloscopes. Other brands and models can be easily added -- see the developer notes on "Adding support for a new Oscilloscope"._
+_Note: At present, `grab-o-scope` supports the Rigol DHO924, DS1054Z, and MSO1074Z oscilloscopes. Other brands and models can be easily added -- see the developer notes on "Adding support for a new Oscilloscope"._
 
 ## Features
 

--- a/grab_o_scope.py
+++ b/grab_o_scope.py
@@ -58,6 +58,15 @@ class RigolDS1054ZGrabber(Grabber):
         buf = instrument.query_binary_values(':DISP:DATA? ON,0,PNG', datatype='B')
         return buf
 
+class RigolMSO1074ZGrabber(Grabber):
+    """Grabber for the Rigol MSO1074Z oscilloscope."""
+    IDN_PATTERN = r'RIGOL TECHNOLOGIES,MSO1\w+Z,.*'
+
+    @classmethod
+    def capture_screen(cls, instrument):
+        buf = instrument.query_binary_values(':DISP:DATA? ON,0,PNG', datatype='B')
+        return buf
+
 # ******************************************************************************
 # Add device-specific subclasses of Grabber above this line.
 # ******************************************************************************
@@ -69,6 +78,7 @@ class GrabOScope:
         Keysight3000XGrabber,
         RigolDHO924Grabber,
         RigolDS1054ZGrabber,
+        RigolMSO1074ZGrabber,
     ]
 
     def __init__(self, options):


### PR DESCRIPTION
Add `Grabber` instance for Rigol MSO1074 and MSO1104 oscilloscopes. Specify `pyvisa-py` version in Pipfile to ensure the fix from pyvisa/pyvisa-py#417 is picked up (version 0.5.1 is in the Debian stable repository as of now).